### PR TITLE
Revert "Upgrade t-digest to latest release (#7029)" (#7069)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -241,7 +241,7 @@ com.google.oauth-client:google-oauth-client:1.30.3
 com.jayway.jsonpath:json-path:2.4.0
 com.lmax:disruptor:3.3.4
 com.ning:async-http-client:1.9.21
-com.tdunning:t-digest:3.3
+com.tdunning:t-digest:3.2
 com.typesafe.netty:netty-reactive-streams-http:2.0.4
 com.typesafe.netty:netty-reactive-streams:2.0.4
 com.typesafe.scala-logging:scala-logging_2.11:3.9.0

--- a/pom.xml
+++ b/pom.xml
@@ -987,7 +987,7 @@
       <dependency>
         <groupId>com.tdunning</groupId>
         <artifactId>t-digest</artifactId>
-        <version>3.3</version>
+        <version>3.2</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>


### PR DESCRIPTION
We found that the latest T-Digest version the following test fails.
- PreAggregatedPercentileTDigestStarTreeV2Test
- The test uses random seed for generating data, so it doesn't always fail.
- Changing the random seed as follows will make the test fail consistently.

In `BaseStarTreeV2Test, modify line that sets the random seed as follows:`

```
  private static final Random RANDOM = new Random(1);
```

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
