### PR TITLE
Make BitmapDocIdSetOperator a top level operator (#7068)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BitmapDocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BitmapDocIdSetOperator.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.roaringbitmap.ImmutableBitmapDataProvider;
+import org.roaringbitmap.IntIterator;
+
+
+/**
+ * The <code>BitmapDocIdSetOperator</code> takes a bitmap of document ids and returns blocks of document ids.
+ * <p>Should call {@link #nextBlock()} multiple times until it returns <code>null</code> (already exhausts all the
+ * documents) or already gathered enough documents (for selection queries).
+ */
+public class BitmapDocIdSetOperator extends BaseOperator<DocIdSetBlock> {
+  private static final String OPERATOR_NAME = "BitmapDocIdSetOperator";
+
+  // TODO: Consider using BatchIterator to fill the document ids. Currently BatchIterator only reads bits for one
+  //       container instead of trying to fill up the buffer with bits from multiple containers. If in the future
+  //       BatchIterator provides an API to fill up the buffer, switch to BatchIterator.
+  private final IntIterator _intIterator;
+  private final int[] _docIdBuffer;
+
+  public BitmapDocIdSetOperator(ImmutableBitmapDataProvider bitmap) {
+    _intIterator = bitmap.getIntIterator();
+    _docIdBuffer = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+  }
+
+  public BitmapDocIdSetOperator(ImmutableBitmapDataProvider bitmap, int numDocs) {
+    _intIterator = bitmap.getIntIterator();
+    _docIdBuffer = new int[Math.min(numDocs, DocIdSetPlanNode.MAX_DOC_PER_CALL)];
+  }
+
+  public BitmapDocIdSetOperator(ImmutableBitmapDataProvider bitmap, int[] docIdBuffer) {
+    _intIterator = bitmap.getIntIterator();
+    _docIdBuffer = docIdBuffer;
+  }
+
+  @Override
+  protected DocIdSetBlock getNextBlock() {
+    int bufferSize = _docIdBuffer.length;
+    int index = 0;
+    while (index < bufferSize && _intIterator.hasNext()) {
+      _docIdBuffer[index++] = _intIterator.next();
+    }
+    if (index > 0) {
+      return new DocIdSetBlock(_docIdBuffer, index);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.dociditerators;
 
 import java.util.Map;
 import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.BitmapDocIdSetOperator;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
@@ -29,8 +30,9 @@ import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.BitmapDataProvider;
 import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -46,7 +48,6 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
   private final int _endDocId;
 
   private final int[] _docIdBuffer = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-  private int _numDocIdsFilled;
 
   private int _blockEndDocId = 0;
   private PeekableIntIterator _docIdIterator;
@@ -77,7 +78,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
       ProjectionBlock projectionBlock =
           new ProjectionOperator(_dataSourceMap, new RangeDocIdSetOperator(blockStartDocId, _blockEndDocId))
               .nextBlock();
-      MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
+      RoaringBitmap matchingDocIds = new RoaringBitmap();
       processProjectionBlock(projectionBlock, matchingDocIds);
       if (!matchingDocIds.isEmpty()) {
         _docIdIterator = matchingDocIds.getIntIterator();
@@ -108,7 +109,8 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
 
   @Override
   public MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds) {
-    ProjectionOperator projectionOperator = new ProjectionOperator(_dataSourceMap, new BitmapDocIdSetOperator(docIds));
+    ProjectionOperator projectionOperator =
+        new ProjectionOperator(_dataSourceMap, new BitmapDocIdSetOperator(docIds, _docIdBuffer));
     MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
     ProjectionBlock projectionBlock;
     while ((projectionBlock = projectionOperator.nextBlock()) != null) {
@@ -117,14 +119,14 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
     return matchingDocIds;
   }
 
-  @SuppressWarnings("DuplicatedCode")
-  private void processProjectionBlock(ProjectionBlock projectionBlock, MutableRoaringBitmap matchingDocIds) {
+  private void processProjectionBlock(ProjectionBlock projectionBlock, BitmapDataProvider matchingDocIds) {
+    int numDocs = projectionBlock.getNumDocs();
     TransformResultMetadata resultMetadata = _transformFunction.getResultMetadata();
     if (resultMetadata.isSingleValue()) {
-      _numEntriesScanned += _numDocIdsFilled;
+      _numEntriesScanned += numDocs;
       if (resultMetadata.hasDictionary()) {
         int[] dictIds = _transformFunction.transformToDictIdsSV(projectionBlock);
-        for (int i = 0; i < _numDocIdsFilled; i++) {
+        for (int i = 0; i < numDocs; i++) {
           if (_predicateEvaluator.applySV(dictIds[i])) {
             matchingDocIds.add(_docIdBuffer[i]);
           }
@@ -133,7 +135,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
         switch (resultMetadata.getDataType().getStoredType()) {
           case INT:
             int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(intValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -141,7 +143,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case LONG:
             long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(longValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -149,7 +151,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case FLOAT:
             float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(floatValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -157,7 +159,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case DOUBLE:
             double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(doubleValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -165,7 +167,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case STRING:
             String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(stringValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -173,7 +175,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case BYTES:
             byte[][] bytesValues = _transformFunction.transformToBytesValuesSV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               if (_predicateEvaluator.applySV(bytesValues[i])) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
@@ -186,7 +188,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
     } else {
       if (resultMetadata.hasDictionary()) {
         int[][] dictIdsArray = _transformFunction.transformToDictIdsMV(projectionBlock);
-        for (int i = 0; i < _numDocIdsFilled; i++) {
+        for (int i = 0; i < numDocs; i++) {
           int[] dictIds = dictIdsArray[i];
           int numDictIds = dictIds.length;
           _numEntriesScanned += numDictIds;
@@ -198,7 +200,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
         switch (resultMetadata.getDataType().getStoredType()) {
           case INT:
             int[][] intValuesArray = _transformFunction.transformToIntValuesMV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               int[] values = intValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
@@ -209,7 +211,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case LONG:
             long[][] longValuesArray = _transformFunction.transformToLongValuesMV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               long[] values = longValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
@@ -220,7 +222,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case FLOAT:
             float[][] floatValuesArray = _transformFunction.transformToFloatValuesMV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               float[] values = floatValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
@@ -231,7 +233,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case DOUBLE:
             double[][] doubleValuesArray = _transformFunction.transformToDoubleValuesMV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               double[] values = doubleValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
@@ -242,7 +244,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
             break;
           case STRING:
             String[][] valuesArray = _transformFunction.transformToStringValuesMV(projectionBlock);
-            for (int i = 0; i < _numDocIdsFilled; i++) {
+            for (int i = 0; i < numDocs; i++) {
               String[] values = valuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
@@ -269,14 +271,14 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
   private class RangeDocIdSetOperator extends BaseOperator<DocIdSetBlock> {
     static final String OPERATOR_NAME = "RangeDocIdSetOperator";
 
-    private DocIdSetBlock _docIdSetBlock;
+    DocIdSetBlock _docIdSetBlock;
 
     RangeDocIdSetOperator(int startDocId, int endDocId) {
-      _numDocIdsFilled = endDocId - startDocId;
-      for (int i = 0; i < _numDocIdsFilled; i++) {
+      int numDocs = endDocId - startDocId;
+      for (int i = 0; i < numDocs; i++) {
         _docIdBuffer[i] = startDocId + i;
       }
-      _docIdSetBlock = new DocIdSetBlock(_docIdBuffer, _numDocIdsFilled);
+      _docIdSetBlock = new DocIdSetBlock(_docIdBuffer, numDocs);
     }
 
     @Override
@@ -284,37 +286,6 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
       DocIdSetBlock docIdSetBlock = _docIdSetBlock;
       _docIdSetBlock = null;
       return docIdSetBlock;
-    }
-
-    @Override
-    public String getOperatorName() {
-      return OPERATOR_NAME;
-    }
-  }
-
-  /**
-   * NOTE: This operator may contain multiple blocks.
-   */
-  private class BitmapDocIdSetOperator extends BaseOperator<DocIdSetBlock> {
-    static final String OPERATOR_NAME = "BitmapDocIdSetOperator";
-
-    final IntIterator _intIterator;
-
-    BitmapDocIdSetOperator(ImmutableRoaringBitmap bitmap) {
-      _intIterator = bitmap.getIntIterator();
-    }
-
-    @Override
-    protected DocIdSetBlock getNextBlock() {
-      _numDocIdsFilled = 0;
-      while (_numDocIdsFilled < DocIdSetPlanNode.MAX_DOC_PER_CALL && _intIterator.hasNext()) {
-        _docIdBuffer[_numDocIdsFilled++] = _intIterator.next();
-      }
-      if (_numDocIdsFilled > 0) {
-        return new DocIdSetBlock(_docIdBuffer, _numDocIdsFilled);
-      } else {
-        return null;
-      }
     }
 
     @Override


### PR DESCRIPTION
Make BitmapDocIdSetOperator a top level operator so that it can be shared

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
