### PR TITLE
Add Query Options for GroupBy In-Segment Trim  (#7052)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -33,6 +33,8 @@ public class QueryOptions {
   private final boolean _responseFormatSQL;
   private final boolean _preserveType;
   private final boolean _skipUpsert;
+  private final boolean _enableSegmentTrim;
+  private final int _minSegmentTrimSize;
 
   public QueryOptions(@Nullable Map<String, String> queryOptions) {
     if (queryOptions != null) {
@@ -41,12 +43,16 @@ public class QueryOptions {
       _responseFormatSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.RESPONSE_FORMAT));
       _preserveType = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.PRESERVE_TYPE));
       _skipUpsert = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
+      _enableSegmentTrim = isEnableSegmentTrim(queryOptions);
+      _minSegmentTrimSize = getMinSegmentTrimSize(queryOptions);
     } else {
       _timeoutMs = null;
       _groupByModeSQL = false;
       _responseFormatSQL = false;
       _preserveType = false;
       _skipUpsert = false;
+      _enableSegmentTrim = false;
+      _minSegmentTrimSize = -1;
     }
   }
 
@@ -72,6 +78,16 @@ public class QueryOptions {
   }
 
   @Nullable
+  public Boolean isEnableSegmentTrim() {
+    return _enableSegmentTrim;
+  }
+
+  @Nullable
+  public Integer getMinSegmentTrimSize() {
+    return _minSegmentTrimSize;
+  }
+
+  @Nullable
   public static Long getTimeoutMs(Map<String, String> queryOptions) {
     String timeoutMsString = queryOptions.get(Request.QueryOptionKey.TIMEOUT_MS);
     if (timeoutMsString != null) {
@@ -81,5 +97,17 @@ public class QueryOptions {
     } else {
       return null;
     }
+  }
+
+  public static boolean isEnableSegmentTrim(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.ENABLE_SEGMENT_TRIM));
+  }
+
+  public static int getMinSegmentTrimSize(Map<String, String> queryOptions) {
+    String minSegmentTrimSize = queryOptions.get(Request.QueryOptionKey.MIN_SEGMENT_TRIM_SIZE);
+    if (minSegmentTrimSize != null) {
+      return Integer.parseInt(minSegmentTrimSize);
+    }
+    return -1;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByInSegmentTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByInSegmentTrimTest.java
@@ -265,6 +265,20 @@ public class GroupByInSegmentTrimTest {
     expectedSize = 1000;
     data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
 
+    // Testcase4: low limit + low server trim size + query option size
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(minSegmentTrimSize=1000)");
+    trimSize = 0;
+    expectedSize = 1000;
+    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
+
+    // Testcase5: low limit + low server trim size + query option enable
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(enableSegmentTrim=true)");
+    trimSize = 0;
+    expectedSize = 1000;
+    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
+
     return data.toArray(new Object[data.size()][]);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -213,6 +213,8 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         public static final String GROUP_BY_MODE = "groupByMode";
         public static final String SKIP_UPSERT = "skipUpsert";
+        public static final String ENABLE_SEGMENT_TRIM = "enableSegmentTrim";
+        public static final String MIN_SEGMENT_TRIM_SIZE = "minSegmentTrimSize";
       }
     }
   }


### PR DESCRIPTION
Adds query options for groupBy in-segment trim. Two options are added: segmentMinTrimSize and segmentEnableTrim.

If segmentMinTrimSize is set to be positive in the query option, it will override the server config and trigger the trim based on the given number. If segmentEnableTrim is set to be true in the query option, it will trigger the trim based on the server config trim size if configured, or default trim size (5000).

Example:
minTrimSize in server config: 0
Query: "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(segmentMinTrimSize=1000)")
=> max(5*limit, 1000): 1000
=> so expectedSize from each segment: 1000

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
