### PR TITLE
Make TableConfigTunerRegistry configurable to scan packages. (#7089)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -74,6 +74,7 @@ import org.apache.pinot.controller.helix.core.retention.RetentionManager;
 import org.apache.pinot.controller.helix.core.statemodel.LeadControllerResourceMasterSlaveStateModelFactory;
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
+import org.apache.pinot.controller.tuner.TableConfigTunerRegistry;
 import org.apache.pinot.controller.validation.BrokerResourceValidationManager;
 import org.apache.pinot.controller.validation.OfflineSegmentIntervalChecker;
 import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
@@ -176,6 +177,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       _executorService =
           Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("restapi-multiget-thread-%d").build());
     }
+
+    // Initialize the table config tuner registry.
+    TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());
   }
 
   private void inferHostnameIfNeeded(ControllerConf config) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -39,9 +39,8 @@ import static org.apache.pinot.spi.utils.CommonConstants.Controller.DEFAULT_METR
 
 
 public class ControllerConf extends PinotConfiguration {
-  public static final List<String> SUPPORTED_PROTOCOLS = Arrays.asList(
-      CommonConstants.HTTP_PROTOCOL,
-      CommonConstants.HTTPS_PROTOCOL);
+  public static final List<String> SUPPORTED_PROTOCOLS =
+      Arrays.asList(CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL);
 
   public static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   public static final String CONTROLLER_VIP_PORT = "controller.vip.port";
@@ -65,6 +64,10 @@ public class ControllerConf extends PinotConfiguration {
   public static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
+
+  // Comma separated list of list of packages that contain TableConfigTuners to be added to the registry
+  public static final String TABLE_CONFIG_TUNER_PACKAGES = "controller.table.config.tuner.packages";
+  public static final String DEFAULT_TABLE_CONFIG_TUNER_PACKAGES = "org.apache.pinot";
 
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
@@ -91,9 +94,10 @@ public class ControllerConf extends PinotConfiguration {
     public static final String STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS =
         "controller.statuschecker.waitForPushTimeInSeconds";
     public static final String TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
-    public static final String MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = "controller.minion.instances.cleanup.task.frequencyInSeconds";
-    public static final String MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS = "controller.minion.instances.cleanup.task.initialDelaySeconds";
-
+    public static final String MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS =
+        "controller.minion.instances.cleanup.task.frequencyInSeconds";
+    public static final String MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS =
+        "controller.minion.instances.cleanup.task.initialDelaySeconds";
 
     public static final String PINOT_TASK_MANAGER_SCHEDULER_ENABLED = "controller.task.scheduler.enabled";
     @Deprecated
@@ -191,7 +195,7 @@ public class ControllerConf extends PinotConfiguration {
   public ControllerConf() {
     super(new HashMap<>());
   }
-  
+
   public ControllerConf(Map<String, Object> baseProperties) {
     super(baseProperties);
   }
@@ -305,7 +309,7 @@ public class ControllerConf extends PinotConfiguration {
   public String getControllerPort() {
     return getProperty(CONTROLLER_PORT);
   }
-  
+
   public List<String> getControllerAccessProtocols() {
     return getProperty(CONTROLLER_ACCESS_PROTOCOLS,
         getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
@@ -394,7 +398,7 @@ public class ControllerConf extends PinotConfiguration {
 
             // No protocol defines a port as VIP. Fallback on legacy controller.port property.
             .orElseGet(this::getControllerPort));
-  }  
+  }
 
   public String getControllerVipProtocol() {
     return getSupportedProtocol(CONTROLLER_VIP_PROTOCOL);
@@ -439,9 +443,8 @@ public class ControllerConf extends PinotConfiguration {
    * @return
    */
   public int getRealtimeSegmentValidationFrequencyInSeconds() {
-    return Optional
-        .ofNullable(
-            getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
+    return Optional.ofNullable(
+        getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
 
         .orElseGet(() -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
             ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS));
@@ -460,9 +463,8 @@ public class ControllerConf extends PinotConfiguration {
    * @return
    */
   public int getBrokerResourceValidationFrequencyInSeconds() {
-    return Optional
-        .ofNullable(
-            getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
+    return Optional.ofNullable(
+        getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, Integer.class))
 
         .orElseGet(() -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_VALIDATION_MANAGER_FREQUENCY_IN_SECONDS,
             ControllerPeriodicTasksConf.DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS));
@@ -569,7 +571,8 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public void setMinionInstancesCleanupTaskFrequencyInSeconds(int frequencyInSeconds) {
-    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS, Integer.toString(frequencyInSeconds));
+    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
+        Integer.toString(frequencyInSeconds));
   }
 
   public long getMinionInstancesCleanupTaskInitialDelaySeconds() {
@@ -578,7 +581,8 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public void setMinionInstancesCleanupTaskInitialDelaySeconds(int initialDelaySeconds) {
-    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS, Integer.toString(initialDelaySeconds));
+    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
+        Integer.toString(initialDelaySeconds));
   }
 
   public int getDefaultTableMinReplicas() {
@@ -690,7 +694,8 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public String getLeadControllerResourceRebalanceStrategy() {
-    return getProperty(LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY, DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY);
+    return getProperty(LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY,
+        DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY);
   }
 
   public boolean getHLCTablesAllowed() {
@@ -709,6 +714,10 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(CONTROLLER_BROKER_PORT_OVERRIDE, -1);
   }
 
+  public List<String> getTableConfigTunerPackages() {
+    return Arrays.asList(getProperty(TABLE_CONFIG_TUNER_PACKAGES, DEFAULT_TABLE_CONFIG_TUNER_PACKAGES).split("\\s*,\\s*"));
+  }
+
   private long convertPeriodToSeconds(String timeStr) {
     long seconds;
     try {
@@ -722,8 +731,7 @@ public class ControllerConf extends PinotConfiguration {
 
   private String getSupportedProtocol(String property) {
     String value = getProperty(property, CommonConstants.HTTP_PROTOCOL);
-    Preconditions.checkArgument(SUPPORTED_PROTOCOLS.contains(value),
-        "Unsupported %s protocol '%s'", property, value);
+    Preconditions.checkArgument(SUPPORTED_PROTOCOLS.contains(value), "Unsupported %s protocol '%s'", property, value);
     return value;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -65,6 +65,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.recommender.RecommenderDriver;
+import org.apache.pinot.controller.tuner.TableConfigTunerUtils;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -148,7 +149,7 @@ public class PinotTableRestletResource {
 
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
 
-      TableConfigUtils.applyTunerConfig(tableConfig, schema);
+      TableConfigTunerUtils.applyTunerConfig(tableConfig, schema);
 
       // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -52,6 +52,7 @@ import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.tuner.TableConfigTunerUtils;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
@@ -351,7 +352,7 @@ public class TableConfigsRestletResource {
   }
 
   private void tuneConfig(TableConfig tableConfig, Schema schema) {
-    TableConfigUtils.applyTunerConfig(tableConfig, schema);
+    TableConfigTunerUtils.applyTunerConfig(tableConfig, schema);
     TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
@@ -16,25 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.config.table.tuner;
+package org.apache.pinot.controller.tuner;
 
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
-/**
- * Interface for Table Config Tuner.
- */
-public interface TableConfigTuner {
-  /**
-   * Used to initialize underlying implementation with Schema
-   * and custom properties (eg: metrics end point)
-   */
-  void init(TunerConfig props, Schema schema);
+@Tuner(name = "noopConfigTuner")
+public class NoOpTableTableConfigTuner implements TableConfigTuner {
+  @Override
+  public void init(TunerConfig props, Schema schema) {
+  }
 
-  /**
-   * Takes the original TableConfig and returns a tuned one
-   */
-  TableConfig apply(TableConfig initialConfig);
+  @Override
+  public TableConfig apply(TableConfig initialConfig) {
+    return initialConfig;
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.config.tuner;
+package org.apache.pinot.controller.tuner;
 
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
-import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
-import org.apache.pinot.spi.config.table.tuner.Tuner;
 import org.apache.pinot.spi.data.Schema;
 
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
@@ -16,23 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.config.tuner;
+package org.apache.pinot.controller.tuner;
 
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
-import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
-import org.apache.pinot.spi.config.table.tuner.Tuner;
 import org.apache.pinot.spi.data.Schema;
 
 
-@Tuner(name = "noopConfigTuner")
-public class NoOpTableTableConfigTuner implements TableConfigTuner {
-  @Override
-  public void init(TunerConfig props, Schema schema) {
-  }
+/**
+ * Interface for Table Config Tuner.
+ */
+public interface TableConfigTuner {
+  /**
+   * Used to initialize underlying implementation with Schema
+   * and custom properties (eg: metrics end point)
+   */
+  void init(TunerConfig props, Schema schema);
 
-  @Override
-  public TableConfig apply(TableConfig initialConfig) {
-    return initialConfig;
-  }
+  /**
+   * Takes the original TableConfig and returns a tuned one
+   */
+  TableConfig apply(TableConfig initialConfig);
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.tuner;
+
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TunerConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class TableConfigTunerUtils {
+
+  /**
+   * Apply TunerConfig to the tableConfig
+   */
+  public static void applyTunerConfig(TableConfig tableConfig, Schema schema) {
+    TunerConfig tunerConfig = tableConfig.getTunerConfig();
+    if (tunerConfig != null && tunerConfig.getName() != null && !tunerConfig.getName().isEmpty()) {
+      TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(tunerConfig.getName());
+      tuner.init(tunerConfig, schema);
+      tuner.apply(tableConfig);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/Tuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/Tuner.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.config.table.tuner;
+package org.apache.pinot.controller.tuner;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
@@ -16,40 +16,63 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.config.tuner;
+package org.apache.pinot.controller.tuner;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TunerConfig;
-import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.controller.ControllerConf.DEFAULT_TABLE_CONFIG_TUNER_PACKAGES;
 
-public class TunerRegistryTest {
 
-  private static final String TUNER_NAME = "noopConfigTuner";
-  private static TunerConfig _tunerConfig;
+public class RealTimeAutoIndexTunerTest {
+
+  private static final String TABLE_NAME = "test_table";
+  private static final String TUNER_NAME = "realtimeAutoIndexTuner";
+  private TunerConfig _tunerConfig;
+  private Schema schema;
+  private String dimensionColumns[] = {"col1", "col2"};
+  private String metricColumns[] = {"count"};
 
   @BeforeClass
   public void setup() {
+    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension(dimensionColumns[0], FieldSpec.DataType.STRING)
+        .addSingleValueDimension(dimensionColumns[1], FieldSpec.DataType.STRING)
+        .addMetric(metricColumns[0], FieldSpec.DataType.INT).build();
     Map<String, String> props = new HashMap<>();
     _tunerConfig = new TunerConfig(TUNER_NAME, props);
   }
 
   @Test
-  public void testNoOpTableConfigTuner() {
-    Schema schema = new Schema.SchemaBuilder().build();
+  public void testTuner() {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTunerConfig(_tunerConfig).build();
+    TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
     tuner.init(_tunerConfig, schema);
     TableConfig result = tuner.apply(tableConfig);
-    Assert.assertEquals(result, tableConfig);
+
+    IndexingConfig newConfig = result.getIndexingConfig();
+    List<String> invertedIndexColumns = newConfig.getInvertedIndexColumns();
+    Assert.assertTrue(invertedIndexColumns.size() == 2);
+    for (int i = 0; i < dimensionColumns.length; i++) {
+      Assert.assertTrue(invertedIndexColumns.contains(dimensionColumns[i]));
+    }
+
+    List<String> noDictionaryColumns = newConfig.getNoDictionaryColumns();
+    Assert.assertTrue(noDictionaryColumns.size() == 1);
+    Assert.assertEquals(noDictionaryColumns.get(0), metricColumns[0]);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
@@ -16,60 +16,43 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.config.tuner;
+package org.apache.pinot.controller.tuner;
 
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TunerConfig;
-import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.controller.ControllerConf.DEFAULT_TABLE_CONFIG_TUNER_PACKAGES;
 
-public class RealTimeAutoIndexTunerTest {
 
-  private static final String TABLE_NAME = "test_table";
-  private static final String TUNER_NAME = "realtimeAutoIndexTuner";
-  private TunerConfig _tunerConfig;
-  private Schema schema;
-  private String dimensionColumns[] = {"col1", "col2"};
-  private String metricColumns[] = {"count"};
+public class TunerRegistryTest {
+
+  private static final String TUNER_NAME = "noopConfigTuner";
+  private static TunerConfig _tunerConfig;
 
   @BeforeClass
   public void setup() {
-    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension(dimensionColumns[0], FieldSpec.DataType.STRING)
-        .addSingleValueDimension(dimensionColumns[1], FieldSpec.DataType.STRING)
-        .addMetric(metricColumns[0], FieldSpec.DataType.INT).build();
     Map<String, String> props = new HashMap<>();
     _tunerConfig = new TunerConfig(TUNER_NAME, props);
   }
 
   @Test
-  public void testTuner() {
+  public void testNoOpTableConfigTuner() {
+    Schema schema = new Schema.SchemaBuilder().build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTunerConfig(_tunerConfig).build();
+    TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
     tuner.init(_tunerConfig, schema);
     TableConfig result = tuner.apply(tableConfig);
-
-    IndexingConfig newConfig = result.getIndexingConfig();
-    List<String> invertedIndexColumns = newConfig.getInvertedIndexColumns();
-    Assert.assertTrue(invertedIndexColumns.size() == 2);
-    for (int i = 0; i < dimensionColumns.length; i++) {
-      Assert.assertTrue(invertedIndexColumns.contains(dimensionColumns[i]));
-    }
-
-    List<String> noDictionaryColumns = newConfig.getNoDictionaryColumns();
-    Assert.assertTrue(noDictionaryColumns.size() == 1);
-    Assert.assertEquals(noDictionaryColumns.get(0), metricColumns[0]);
+    Assert.assertEquals(result, tableConfig);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.pinot.common.config.tuner.TableConfigTunerRegistry;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.core.util.ReplicationUtils;
@@ -47,13 +46,11 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
-import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
-import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
@@ -655,18 +652,6 @@ public final class TableConfigUtils {
       return indexingColumns.stream().filter(v -> !v.isEmpty()).collect(Collectors.toList());
     }
     return null;
-  }
-
-  /**
-   * Apply TunerConfig to the tableConfig
-   */
-  public static void applyTunerConfig(TableConfig tableConfig, Schema schema) {
-    TunerConfig tunerConfig = tableConfig.getTunerConfig();
-    if (tunerConfig != null && tunerConfig.getName() != null && !tunerConfig.getName().isEmpty()) {
-      TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(tunerConfig.getName());
-      tuner.init(tunerConfig, schema);
-      tuner.apply(tableConfig);
-    }
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
