### PR TITLE
Optimize BaseSingleSegmentConversionExecutor by skipping task if CRC …

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -70,6 +70,14 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     String originalSegmentCrc = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
     String authToken = configs.get(MinionConstants.AUTH_TOKEN);
 
+    long currentSegmentCrc = getSegmentCrc(tableNameWithType, segmentName);
+    if (Long.parseLong(originalSegmentCrc) != currentSegmentCrc) {
+      LOGGER.info("Segment CRC does not match, skip the task. Original CRC: {}, current CRC: {}", originalSegmentCrc,
+          currentSegmentCrc);
+      return new SegmentConversionResult.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)
+          .build();
+    }
+
     LOGGER.info("Start executing {} on table: {}, segment: {} with downloadURL: {}, uploadURL: {}", taskType,
         tableNameWithType, segmentName, downloadURL, uploadURL);
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
@@ -20,12 +20,15 @@ package org.apache.pinot.plugin.minion.tasks;
 
 import com.google.common.base.Preconditions;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 public abstract class BaseTaskExecutor implements PinotTaskExecutor {
@@ -55,5 +58,19 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
     Schema schema = ZKMetadataProvider.getTableSchema(MINION_CONTEXT.getHelixPropertyStore(), tableName);
     Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableName);
     return schema;
+  }
+
+  protected long getSegmentCrc(String tableNameWithType, String segmentName) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    SegmentZKMetadata segmentZKMetadata = tableType == TableType.OFFLINE ? ZKMetadataProvider
+        .getOfflineSegmentZKMetadata(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType, segmentName)
+        : ZKMetadataProvider
+            .getRealtimeSegmentZKMetadata(MINION_CONTEXT.getHelixPropertyStore(), tableNameWithType, segmentName);
+    /*
+     * If the segmentZKMetadata is null, it is likely that the segment has been deleted, return -1 as CRC in this case,
+     * so that task can terminate early when verify CRC. If we throw exception, helix will keep retrying this forever
+     * and task status would be left unchanged without proper cleanup.
+     */
+    return segmentZKMetadata == null ? -1 : segmentZKMetadata.getCrc();
   }
 }


### PR DESCRIPTION
…not match (#7086)

* Optimize BaseSingleSegmentConversionExecutor by skipping task if CRC not match

* add missing return

* eliminate the offline table assumption in getSegmentCrc()

* return -1 instead of throw exception when metadata is null

* throw exception when CRC mismatch

* Return en ampty SegmentConversionResult instead of throw exception when CRC not match

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
