### PR TITLE
Enhance PinotHelixResourceManager.updateInstance() to preserve custom…

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
@@ -21,9 +21,11 @@ package org.apache.pinot.common.utils.config;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.spi.config.instance.Instance;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 
 
@@ -61,26 +63,60 @@ public class InstanceUtils {
    * Returns the Helix InstanceConfig for the given instance.
    */
   public static InstanceConfig toHelixInstanceConfig(Instance instance) {
-    InstanceConfig instanceConfig = InstanceConfig.toInstanceConfig(getHelixInstanceId(instance));
-    List<String> tags = instance.getTags();
-    if (tags != null) {
-      for (String tag : tags) {
-        instanceConfig.addTag(tag);
-      }
+    InstanceConfig instanceConfig = new InstanceConfig(getHelixInstanceId(instance));
+    instanceConfig.setInstanceEnabled(true);
+    updateHelixInstanceConfig(instanceConfig, instance);
+    return instanceConfig;
+  }
+
+  /**
+   * Updates the Helix InstanceConfig with the given instance configuration. Leaves the fields not included in the
+   * instance configuration unchanged.
+   */
+  public static void updateHelixInstanceConfig(InstanceConfig instanceConfig, Instance instance) {
+    ZNRecord znRecord = instanceConfig.getRecord();
+
+    Map<String, String> simpleFields = znRecord.getSimpleFields();
+    simpleFields.put(InstanceConfig.InstanceConfigProperty.HELIX_HOST.name(), instance.getHost());
+    simpleFields.put(InstanceConfig.InstanceConfigProperty.HELIX_PORT.name(), Integer.toString(instance.getPort()));
+    int grpcPort = instance.getGrpcPort();
+    if (grpcPort > 0) {
+      simpleFields.put(Helix.Instance.GRPC_PORT_KEY, Integer.toString(grpcPort));
+    } else {
+      simpleFields.remove(Helix.Instance.GRPC_PORT_KEY);
     }
+    int adminPort = instance.getAdminPort();
+    if (adminPort > 0) {
+      simpleFields.put(Helix.Instance.ADMIN_PORT_KEY, Integer.toString(adminPort));
+    } else {
+      simpleFields.remove(Helix.Instance.ADMIN_PORT_KEY);
+    }
+    boolean queriesDisabled = instance.isQueriesDisabled();
+    if (queriesDisabled) {
+      simpleFields.put(Helix.QUERIES_DISABLED, Boolean.toString(true));
+    } else {
+      simpleFields.remove(Helix.QUERIES_DISABLED);
+    }
+
+    Map<String, List<String>> listFields = znRecord.getListFields();
+    List<String> tags = instance.getTags();
+    String tagsKey = InstanceConfig.InstanceConfigProperty.TAG_LIST.name();
+    if (CollectionUtils.isNotEmpty(tags)) {
+      listFields.put(tagsKey, tags);
+    } else {
+      listFields.remove(tagsKey);
+    }
+
+    Map<String, Map<String, String>> mapFields = znRecord.getMapFields();
     Map<String, Integer> pools = instance.getPools();
-    if (pools != null && !pools.isEmpty()) {
+    if (MapUtils.isNotEmpty(pools)) {
       Map<String, String> mapValue = new TreeMap<>();
       for (Map.Entry<String, Integer> entry : pools.entrySet()) {
         mapValue.put(entry.getKey(), entry.getValue().toString());
       }
-      instanceConfig.getRecord().setMapField(POOL_KEY, mapValue);
+      mapFields.put(POOL_KEY, mapValue);
+    } else {
+      mapFields.remove(POOL_KEY);
     }
-    instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY, Integer.toString(instance.getGrpcPort()));
-    instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, Integer.toString(instance.getAdminPort()));
-    if (instance.isQueriesDisabled()) {
-      instanceConfig.getRecord().setBooleanField(Helix.QUERIES_DISABLED, true);
-    }
-    return instanceConfig;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/InstanceUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/InstanceUtilsTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.spi.config.instance.Instance;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class InstanceUtilsTest {
+
+  @Test
+  public void testToHelixInstanceConfig() {
+    Instance instance = new Instance("localhost", 1234, InstanceType.CONTROLLER, null, null, 0, 0, false);
+    InstanceConfig instanceConfig = InstanceUtils.toHelixInstanceConfig(instance);
+    assertEquals(instanceConfig.getInstanceName(), "Controller_localhost_1234");
+    assertTrue(instanceConfig.getInstanceEnabled());
+    assertEquals(instanceConfig.getHostName(), "localhost");
+    assertEquals(instanceConfig.getPort(), "1234");
+    assertTrue(instanceConfig.getTags().isEmpty());
+    ZNRecord znRecord = instanceConfig.getRecord();
+    assertNull(znRecord.getMapField(InstanceUtils.POOL_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED));
+
+    List<String> tags = Collections.singletonList("DefaultTenant_BROKER");
+    instance = new Instance("localhost", 2345, InstanceType.BROKER, tags, null, 0, 0, false);
+    instanceConfig = InstanceUtils.toHelixInstanceConfig(instance);
+    assertEquals(instanceConfig.getInstanceName(), "Broker_localhost_2345");
+    assertTrue(instanceConfig.getInstanceEnabled());
+    assertEquals(instanceConfig.getHostName(), "localhost");
+    assertEquals(instanceConfig.getPort(), "2345");
+    assertEquals(instanceConfig.getTags(), tags);
+    znRecord = instanceConfig.getRecord();
+    assertNull(znRecord.getMapField(InstanceUtils.POOL_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED));
+
+    tags = Arrays.asList("T1_OFFLINE", "T2_REALTIME");
+    Map<String, Integer> poolMap = new TreeMap<>();
+    poolMap.put("T1_OFFLINE", 0);
+    poolMap.put("T2_REALTIME", 1);
+    instance = new Instance("localhost", 3456, InstanceType.SERVER, tags, poolMap, 123, 234, true);
+    instanceConfig = InstanceUtils.toHelixInstanceConfig(instance);
+    assertEquals(instanceConfig.getInstanceName(), "Server_localhost_3456");
+    assertTrue(instanceConfig.getInstanceEnabled());
+    assertEquals(instanceConfig.getHostName(), "localhost");
+    assertEquals(instanceConfig.getPort(), "3456");
+    assertEquals(instanceConfig.getTags(), tags);
+    znRecord = instanceConfig.getRecord();
+    Map<String, String> expectedPoolMap = new TreeMap<>();
+    expectedPoolMap.put("T1_OFFLINE", "0");
+    expectedPoolMap.put("T2_REALTIME", "1");
+    assertEquals(znRecord.getMapField(InstanceUtils.POOL_KEY), expectedPoolMap);
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY), "123");
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY), "234");
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED), "true");
+
+    tags = Collections.singletonList("minion_untagged");
+    instance = new Instance("localhost", 4567, InstanceType.MINION, tags, null, 0, 0, false);
+    instanceConfig = InstanceUtils.toHelixInstanceConfig(instance);
+    assertEquals(instanceConfig.getInstanceName(), "Minion_localhost_4567");
+    assertTrue(instanceConfig.getInstanceEnabled());
+    assertEquals(instanceConfig.getHostName(), "localhost");
+    assertEquals(instanceConfig.getPort(), "4567");
+    assertEquals(instanceConfig.getTags(), tags);
+    znRecord = instanceConfig.getRecord();
+    assertNull(znRecord.getMapField(InstanceUtils.POOL_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY));
+    assertNull(znRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED));
+  }
+
+  @Test
+  public void testUpdateHelixInstanceConfig() {
+    Instance instance =
+        new Instance("localhost", 1234, InstanceType.SERVER, Collections.singletonList("DefaultTenant_OFFLINE"), null,
+            0, 123, false);
+    InstanceConfig instanceConfig = InstanceUtils.toHelixInstanceConfig(instance);
+
+    // Put some custom fields, which should not be updated
+    ZNRecord znRecord = instanceConfig.getRecord();
+    znRecord.setSimpleField("customSimple", "potato");
+    List<String> customList = Arrays.asList("foo", "bar");
+    znRecord.setListField("customList", customList);
+    Map<String, String> customMap = Collections.singletonMap("foo", "bar");
+    znRecord.setMapField("customMap", customMap);
+
+    List<String> tags = Arrays.asList("T1_OFFLINE", "T2_REALTIME");
+    Map<String, Integer> poolMap = new TreeMap<>();
+    poolMap.put("T1_OFFLINE", 0);
+    poolMap.put("T2_REALTIME", 1);
+    instance = new Instance("myHost", 2345, InstanceType.SERVER, tags, poolMap, 123, 234, true);
+    InstanceUtils.updateHelixInstanceConfig(instanceConfig, instance);
+
+    // Instance name should not change
+    assertEquals(instanceConfig.getInstanceName(), "Server_localhost_1234");
+    assertTrue(instanceConfig.getInstanceEnabled());
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "2345");
+    assertEquals(instanceConfig.getTags(), tags);
+    znRecord = instanceConfig.getRecord();
+    Map<String, String> expectedPoolMap = new TreeMap<>();
+    expectedPoolMap.put("T1_OFFLINE", "0");
+    expectedPoolMap.put("T2_REALTIME", "1");
+    assertEquals(znRecord.getMapField(InstanceUtils.POOL_KEY), expectedPoolMap);
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY), "123");
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY), "234");
+    assertEquals(znRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED), "true");
+
+    // Custom fields should be preserved
+    assertEquals(znRecord.getSimpleField("customSimple"), "potato");
+    assertEquals(znRecord.getListField("customList"), customList);
+    assertEquals(znRecord.getMapField("customMap"), customMap);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -204,14 +204,16 @@ public class PinotQueryResource {
       return QueryException.INTERNAL_ERROR.toString();
     }
 
-    String hostNameWithPrefix = instanceConfig.getHostName();
+    String hostName = instanceConfig.getHostName();
+    // Backward-compatible with legacy hostname of format 'Broker_<hostname>'
+    if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
+      hostName = hostName.substring(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE.length());
+    }
 
     String protocol = _controllerConf.getControllerBrokerProtocol();
     int port = _controllerConf.getControllerBrokerPortOverride() > 0 ? _controllerConf.getControllerBrokerPortOverride()
         : Integer.parseInt(instanceConfig.getPort());
-    String url =
-        getQueryURL(protocol, hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1), String.valueOf(port),
-            querySyntax);
+    String url = getQueryURL(protocol, hostName, String.valueOf(port), querySyntax);
     ObjectNode requestJson = getRequestJson(query, traceEnabled, queryOptions, querySyntax);
 
     // forward client-supplied headers

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -128,10 +128,10 @@ public class PinotInstanceRestletResourceTest {
     checkNumInstances(listInstancesUrl, counts[0] + 4);
 
     // Check that the instances are properly created
-    checkInstanceInfo("Broker_1.2.3.4_1234", "Broker_1.2.3.4", 1234, new String[0], null, null, false);
-    checkInstanceInfo("Server_1.2.3.4_2345", "Server_1.2.3.4", 2345, new String[0], null, null, 8090, 8091, false);
-    checkInstanceInfo("Broker_2.3.4.5_1234", "Broker_2.3.4.5", 1234, new String[]{"tag_BROKER"}, null, null, false);
-    checkInstanceInfo("Server_2.3.4.5_2345", "Server_2.3.4.5", 2345, new String[]{"tag_OFFLINE", "tag_REALTIME"},
+    checkInstanceInfo("Broker_1.2.3.4_1234", "1.2.3.4", 1234, new String[0], null, null, false);
+    checkInstanceInfo("Server_1.2.3.4_2345", "1.2.3.4", 2345, new String[0], null, null, 8090, 8091, false);
+    checkInstanceInfo("Broker_2.3.4.5_1234", "2.3.4.5", 1234, new String[]{"tag_BROKER"}, null, null, false);
+    checkInstanceInfo("Server_2.3.4.5_2345", "2.3.4.5", 2345, new String[]{"tag_OFFLINE", "tag_REALTIME"},
         new String[]{"tag_OFFLINE", "tag_REALTIME"}, new int[]{0, 1}, 18090, 18091, false);
 
     // Test PUT Instance API
@@ -150,9 +150,8 @@ public class PinotInstanceRestletResourceTest {
     String serverInstanceUrl = ControllerTestUtils.getControllerRequestURLBuilder().forInstance(serverInstanceId);
     ControllerTestUtils.sendPutRequest(serverInstanceUrl, newServerInstance.toJsonString());
 
-    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{newBrokerTag}, null, null, false);
-    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null, 28090, 28091,
-        true);
+    checkInstanceInfo(brokerInstanceId, "1.2.3.4", 1234, new String[]{newBrokerTag}, null, null, false);
+    checkInstanceInfo(serverInstanceId, "1.2.3.4", 2345, new String[]{newServerTag}, null, null, 28090, 28091, true);
 
     // Test Instance updateTags API
     String brokerInstanceUpdateTagsUrl = ControllerTestUtils.getControllerRequestURLBuilder()
@@ -162,9 +161,9 @@ public class PinotInstanceRestletResourceTest {
         .forInstanceUpdateTags(serverInstanceId,
             Lists.newArrayList("tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"));
     ControllerTestUtils.sendPutRequest(serverInstanceUpdateTagsUrl);
-    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null, null,
+    checkInstanceInfo(brokerInstanceId, "1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null, null,
         false);
-    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345,
+    checkInstanceInfo(serverInstanceId, "1.2.3.4", 2345,
         new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null, 28090, 28091, true);
   }
 


### PR DESCRIPTION
… fields (#7098)

When using rest API to update the instance config, preserve the custom fields. Some example custom fields are: fault domain, resource info etc.
Also add support to custom broker hostname in PinotQueryResource

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
