### PR TITLE
Added support for additional mvn options (#7103)

### DIFF
--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -35,6 +35,8 @@ function usage() {
   echo -e "    To compare this checkout with previous commit: '${cmdName} -w /tmp/wd'"
   echo -e "    To compare this checkout with some older tag or hash: '${cmdName} -o release-0.7.1 -w /tmp/wd'"
   echo -e "    To compare any two previous tags or hashes: '${cmdName} -o release-0.7.1 -n 637cc3494 -w /tmp/wd"
+  echo -e "Environment:"
+  echo -e "    Additional maven build options can be passed in via environment varibale MAVEN_OPTS"
   exit 1
 }
 
@@ -50,7 +52,7 @@ function checkoutAndBuild() {
   # Pull the tag list so that we can check out by tag name
   git fetch --tags || exit 1
   git checkout $commitHash || exit 1
-  mvn install package -DskipTests -Pbin-dist -T 4 -Djdk.version=8 || exit 1
+  mvn install package -DskipTests -Pbin-dist -T 4 -Djdk.version=8 ${MAVEN_OPTS} || exit 1
   popd || exit 1
   exit 0
 }
@@ -117,7 +119,7 @@ workingDir=$(absPath "$workingDir")
 newTargetDir="$workingDir"/newTargetDir
 if [ -z "$newerCommit" ]; then
   echo "Compiling current tree as newer version"
-  (cd $cmdDir/.. && mvn install package -DskipTests -Pbin-dist -T 4 -D jdk.version=8 && mvn -pl pinot-tools package -T 4 -DskipTests -Djdk.version=8 && mvn -pl pinot-integration-tests package -T 4 -DskipTests -Djdk.version=8)
+  (cd $cmdDir/.. && mvn install package -DskipTests -Pbin-dist -T 4 -D jdk.version=8 ${MAVEN_OPTS} && mvn -pl pinot-tools package -T 4 -DskipTests -Djdk.version=8 ${MAVEN_OPTS} && mvn -pl pinot-integration-tests package -T 4 -DskipTests -Djdk.version=8 ${MAVEN_OPTS})
   if [ $? -ne 0 ]; then
     echo Compile failed.
     exit 1


### PR DESCRIPTION
Additional options (e.g. proxy settings) can be passed for maven build commands
in firewalled environments

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
