### PR TITLE
Add minion metrics of task queueing time and task numbers (#7099)

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionGauge.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionGauge.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.metrics.AbstractMetrics;
 
 
 public enum MinionGauge implements AbstractMetrics.Gauge {
+  NUMBER_OF_TASKS("tasks", true),
   ;
 
   private final String _gaugeName;

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionQueryPhase.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionQueryPhase.java
@@ -23,7 +23,8 @@ import org.apache.pinot.common.metrics.AbstractMetrics;
 
 
 public enum MinionQueryPhase implements AbstractMetrics.QueryPhase {
-  TASK_EXECUTION;
+  TASK_EXECUTION,
+  TASK_QUEUEING;
 
   private final String _queryPhaseName;
 


### PR DESCRIPTION
* Add minion metrics of task queueing time and task numbers

* put the core logic into a dedicated function

* try/finally in run() and unify granularity of TASK_EXECUTION/TASK_QUEUEING as milliseconds

* emit TASK_EXECUTION metric in finally statement

* add Ms suffix to variable name

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
