### PR TITLE
Allow updating controller and broker helix hostname  (#7064)

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.Instance.INSTANCE_ID_KEY;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT;
+import static org.testng.Assert.assertEquals;
+
+
+public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+  }
+
+  @Test
+  public void testHostnamePortOverride()
+      throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    properties.put(INSTANCE_ID_KEY, "myInstance");
+    properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
+    properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
+
+    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
+    brokerStarter.init(new PinotConfiguration(properties));
+    brokerStarter.start();
+
+    String instanceId = brokerStarter.getInstanceId();
+    assertEquals(instanceId, "myInstance");
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    brokerStarter.stop();
+  }
+
+  @Test
+  public void testDefaultInstanceId()
+      throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
+    properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
+
+    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
+    brokerStarter.init(new PinotConfiguration(properties));
+    brokerStarter.start();
+
+    String instanceId = brokerStarter.getInstanceId();
+    assertEquals(instanceId, "Broker_myHost_1234");
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    brokerStarter.stop();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.helix;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class HelixHelperTest {
+
+  @Test
+  public void testUpdateHostName() {
+    String instanceId = "myInstance";
+    InstanceConfig instanceConfig = new InstanceConfig(instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertNull(instanceConfig.getHostName());
+    assertNull(instanceConfig.getPort());
+
+    assertTrue(HelixHelper.updateHostnamePort(instanceConfig, "myHost", 1234));
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    assertTrue(HelixHelper.updateHostnamePort(instanceConfig, "myHost2", 1234));
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost2");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    assertTrue(HelixHelper.updateHostnamePort(instanceConfig, "myHost2", 2345));
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost2");
+    assertEquals(instanceConfig.getPort(), "2345");
+
+    assertFalse(HelixHelper.updateHostnamePort(instanceConfig, "myHost2", 2345));
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost2");
+    assertEquals(instanceConfig.getPort(), "2345");
+  }
+
+  @Test
+  public void testAddDefaultTags() {
+    String instanceId = "myInstance";
+    InstanceConfig instanceConfig = new InstanceConfig(instanceId);
+    List<String> defaultTags = Arrays.asList("tag1", "tag2");
+    assertTrue(HelixHelper.addDefaultTags(instanceConfig, () -> defaultTags));
+    assertEquals(instanceConfig.getTags(), defaultTags);
+
+    assertFalse(HelixHelper.addDefaultTags(instanceConfig, () -> defaultTags));
+    assertEquals(instanceConfig.getTags(), defaultTags);
+
+    List<String> otherTags = Arrays.asList("tag3", "tag4");
+    assertFalse(HelixHelper.addDefaultTags(instanceConfig, () -> otherTags));
+    assertEquals(instanceConfig.getTags(), defaultTags);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -35,6 +35,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
+import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.DEFAULT_METRICS_PREFIX;
 
 
@@ -310,6 +311,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public String getControllerPort() {
     return getProperty(CONTROLLER_PORT);
+  }
+
+  public String getInstanceId() {
+    return getProperty(CONFIG_OF_INSTANCE_ID);
   }
 
   public List<String> getControllerAccessProtocols() {
@@ -727,7 +732,8 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public List<String> getTableConfigTunerPackages() {
-    return Arrays.asList(getProperty(TABLE_CONFIG_TUNER_PACKAGES, DEFAULT_TABLE_CONFIG_TUNER_PACKAGES).split("\\s*,\\s*"));
+    return Arrays
+        .asList(getProperty(TABLE_CONFIG_TUNER_PACKAGES, DEFAULT_TABLE_CONFIG_TUNER_PACKAGES).split("\\s*,\\s*"));
   }
 
   private long convertPeriodToSeconds(String timeStr) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.ControllerConf.CONTROLLER_HOST;
+import static org.apache.pinot.controller.ControllerConf.CONTROLLER_PORT;
+import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
+import static org.testng.Assert.assertEquals;
+
+
+public class ControllerStarterTest extends ControllerTest {
+  private final Map<String, Object> _configOverride = new HashMap<>();
+
+  @Override
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> defaultConfig = super.getDefaultControllerConfiguration();
+    defaultConfig.putAll(_configOverride);
+    return defaultConfig;
+  }
+
+  @Test
+  public void testHostnamePortOverride()
+      throws Exception {
+    _configOverride.put(CONFIG_OF_INSTANCE_ID, "myInstance");
+    _configOverride.put(CONTROLLER_HOST, "myHost");
+    _configOverride.put(CONTROLLER_PORT, 1234);
+
+    startZk();
+    startController();
+
+    String instanceId = _controllerStarter.getInstanceId();
+    assertEquals(instanceId, "myInstance");
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testDefaultInstanceId()
+      throws Exception {
+    _configOverride.put(CONTROLLER_HOST, "myHost");
+    _configOverride.put(CONTROLLER_PORT, 1234);
+
+    startZk();
+    startController();
+
+    String instanceId = _controllerStarter.getInstanceId();
+    assertEquals(instanceId, "Controller_myHost_1234");
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -33,11 +32,11 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
@@ -55,6 +54,7 @@ import org.apache.pinot.common.restlet.resources.SystemResourceInfo;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.ServiceStatus.Status;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.query.request.context.ThreadTimer;
@@ -115,7 +115,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected String _zkAddress;
   protected PinotConfiguration _serverConf;
   protected List<ListenerConfig> _listenerConfigs;
-  protected String _host;
+  protected String _hostname;
   protected int _port;
   protected String _instanceId;
   protected HelixConfigScope _instanceConfigScope;
@@ -136,14 +136,14 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _helixClusterName = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME);
     _zkAddress = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER);
 
-    _host = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_HOST,
+    _hostname = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_HOST,
         _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
             : NetUtils.getHostAddress());
     _port = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_PORT, Helix.DEFAULT_SERVER_NETTY_PORT);
 
     String instanceId = _serverConf.getProperty(Server.CONFIG_OF_INSTANCE_ID);
     if (instanceId == null) {
-      instanceId = Helix.PREFIX_OF_SERVER_INSTANCE + _host + "_" + _port;
+      instanceId = Helix.PREFIX_OF_SERVER_INSTANCE + _hostname + "_" + _port;
       _serverConf.addProperty(Server.CONFIG_OF_INSTANCE_ID, instanceId);
     }
     _instanceId = instanceId;
@@ -162,8 +162,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     // Set data table version send to broker.
     DataTableBuilder.setCurrentDataTableVersion(_serverConf
-        .getProperty(Server.CONFIG_OF_CURRENT_DATA_TABLE_VERSION,
-            Server.DEFAULT_CURRENT_DATA_TABLE_VERSION));
+        .getProperty(Server.CONFIG_OF_CURRENT_DATA_TABLE_VERSION, Server.DEFAULT_CURRENT_DATA_TABLE_VERSION));
   }
 
   /**
@@ -172,7 +171,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
    */
   @Nullable
   private PinotEnvironmentProvider initializePinotEnvironmentProvider() {
-    PinotConfiguration environmentProviderConfigs = _serverConf.subset(Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
+    PinotConfiguration environmentProviderConfigs =
+        _serverConf.subset(Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
     if (environmentProviderConfigs.toMap().isEmpty()) {
       LOGGER.info("No environment provider config values provided for server property: {}",
           Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
@@ -255,66 +255,36 @@ public abstract class BaseServerStarter implements ServiceStartable {
         new ServiceStatus.MultipleCallbackServiceStatusCallback(serviceStatusCallbackListBuilder.build()));
   }
 
-  private void updateInstanceConfigIfNeeded(String host, int port) {
-    InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(_helixClusterName, _instanceId);
-    boolean needToUpdateInstanceConfig = false;
-
-    // Add default instance tags if not exist
-    List<String> instanceTags = instanceConfig.getTags();
-    if (instanceTags == null || instanceTags.size() == 0) {
+  private void updateInstanceConfigIfNeeded() {
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, _instanceId);
+    boolean updated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
+    updated |= HelixHelper.addDefaultTags(instanceConfig, () -> {
       if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_helixManager.getHelixPropertyStore())) {
-        instanceConfig.addTag(TagNameUtils.getOfflineTagForTenant(null));
-        instanceConfig.addTag(TagNameUtils.getRealtimeTagForTenant(null));
+        return Arrays.asList(TagNameUtils.getOfflineTagForTenant(null), TagNameUtils.getRealtimeTagForTenant(null));
       } else {
-        instanceConfig.addTag(Helix.UNTAGGED_SERVER_INSTANCE);
+        return Collections.singletonList(Helix.UNTAGGED_SERVER_INSTANCE);
       }
-      needToUpdateInstanceConfig = true;
-    }
-
-    // Update host and port if needed
-    if (!host.equals(instanceConfig.getHostName())) {
-      instanceConfig.setHostName(host);
-      needToUpdateInstanceConfig = true;
-    }
-    String portStr = Integer.toString(port);
-    if (!portStr.equals(instanceConfig.getPort())) {
-      instanceConfig.setPort(portStr);
-      needToUpdateInstanceConfig = true;
-    }
-
+    });
     // Update instance config with environment properties
     if (_pinotEnvironmentProvider != null) {
       // Retrieve failure domain information and add to the environment properties map
       String failureDomain = _pinotEnvironmentProvider.getFailureDomain();
-      Map<String, String> environmentProperties = new HashMap<>();
-      environmentProperties.put(CommonConstants.INSTANCE_FAILURE_DOMAIN, failureDomain);
+      Map<String, String> environmentProperties =
+          Collections.singletonMap(CommonConstants.INSTANCE_FAILURE_DOMAIN, failureDomain);
 
       // Fetch existing environment properties map from instance configs
-      Map<String, String> existingEnvironmentConfigsMap = instanceConfig.getRecord().getMapField(
-          CommonConstants.ENVIRONMENT_IDENTIFIER);
+      ZNRecord znRecord = instanceConfig.getRecord();
+      Map<String, String> existingEnvironmentConfigsMap = znRecord.getMapField(CommonConstants.ENVIRONMENT_IDENTIFIER);
 
-      if (existingEnvironmentConfigsMap == null || !existingEnvironmentConfigsMap.equals(environmentProperties)) {
-        instanceConfig.getRecord().setMapField(CommonConstants.ENVIRONMENT_IDENTIFIER, environmentProperties);
-        LOGGER.info("Adding environment properties: {} for instance: {}", environmentProperties, _instanceId);
-        needToUpdateInstanceConfig = true;
+      if (!environmentProperties.equals(existingEnvironmentConfigsMap)) {
+        LOGGER.info("Updating instance: {} with environment properties: {}", environmentProperties, _instanceId);
+        znRecord.setMapField(CommonConstants.ENVIRONMENT_IDENTIFIER, environmentProperties);
+        updated = true;
       }
     }
-
-    if (needToUpdateInstanceConfig) {
-      LOGGER.info("Updating instance config for instance: {} with instance tags: {}, host: {}, port: {}", _instanceId,
-          instanceTags, host, port);
-    } else {
-      LOGGER.info("Instance config for instance: {} has instance tags: {}, host: {}, port: {}, no need to update",
-          _instanceId, instanceTags, host, port);
-      return;
+    if (updated) {
+      HelixHelper.updateInstanceConfig(_helixManager, instanceConfig);
     }
-
-    // NOTE: Use HelixDataAccessor.setProperty() instead of HelixAdmin.setInstanceConfig() because the latter explicitly
-    // forbids instance host/port modification
-    HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
-    Preconditions.checkState(
-        helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().instanceConfig(_instanceId), instanceConfig),
-        "Failed to update instance config");
   }
 
   private void setupHelixSystemProperties() {
@@ -410,7 +380,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
     LOGGER.info("Connecting Helix manager");
     _helixManager.connect();
     _helixAdmin = _helixManager.getClusterManagmentTool();
-    updateInstanceConfigIfNeeded(_host, _port);
+    updateInstanceConfigIfNeeded();
 
     // Start restlet server for admin API endpoint
     String accessControlFactoryClass =
@@ -431,8 +401,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _adminApiApplication.start(_listenerConfigs);
 
     // Update http admin port
-    Optional<ListenerConfig> adminApiHttp = _listenerConfigs.stream()
-        .filter(listener -> CommonConstants.HTTP_PROTOCOL.equals(listener.getProtocol())).findFirst();
+    Optional<ListenerConfig> adminApiHttp =
+        _listenerConfigs.stream().filter(listener -> CommonConstants.HTTP_PROTOCOL.equals(listener.getProtocol()))
+            .findFirst();
     if (adminApiHttp.isPresent()) {
       _helixAdmin.setConfig(_instanceConfigScope,
           Collections.singletonMap(Instance.ADMIN_PORT_KEY, String.valueOf(adminApiHttp.get().getPort())));
@@ -441,8 +412,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
     }
 
     // Update https admin port
-    Optional<ListenerConfig> adminApiHttps = _listenerConfigs.stream()
-        .filter(listener -> CommonConstants.HTTPS_PROTOCOL.equals(listener.getProtocol())).findFirst();
+    Optional<ListenerConfig> adminApiHttps =
+        _listenerConfigs.stream().filter(listener -> CommonConstants.HTTPS_PROTOCOL.equals(listener.getProtocol()))
+            .findFirst();
     if (adminApiHttps.isPresent()) {
       _helixAdmin.setConfig(_instanceConfigScope,
           Collections.singletonMap(Instance.ADMIN_HTTPS_PORT_KEY, String.valueOf(adminApiHttps.get().getPort())));
@@ -501,7 +473,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
     serverMetrics.addCallbackGauge("memory.allocationFailureCount", PinotDataBuffer::getAllocationFailureCount);
 
     // Track metric for queries disabled
-    _serverQueriesDisabledTracker = new ServerQueriesDisabledTracker(_helixClusterName, _instanceId, _helixManager, serverMetrics);
+    _serverQueriesDisabledTracker =
+        new ServerQueriesDisabledTracker(_helixClusterName, _instanceId, _helixManager, serverMetrics);
     _serverQueriesDisabledTracker.start();
 
     _realtimeLuceneIndexRefreshState = RealtimeLuceneIndexRefreshState.getInstance();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -405,6 +405,8 @@ public class CommonConstants {
     // but we keep this default for backward compatibility in case someone relies on this format
     // see Server or Broker class for correct prefix format you should use
     public static final String DEFAULT_METRICS_PREFIX = "pinot.controller.";
+
+    public static final String CONFIG_OF_INSTANCE_ID = "pinot.controller.instance.id";
   }
 
   public static class Minion {


### PR DESCRIPTION
Allow us to update Helix hostname property so controllers, brokers and minions can be replaced easily.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
