### PR TITLE
adding json-bigInt package to parse long values in json (#7120)

### DIFF
--- a/pinot-controller/src/main/resources/app/components/SideBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/SideBar.tsx
@@ -98,7 +98,7 @@ const useStyles = makeStyles((theme: Theme) =>
       position: 'absolute',
       whiteSpace: 'nowrap',
       backgroundColor: 'inherit',
-      padding: '8px 8px 8px 0',
+      padding: '7px 8px 7px 0',
       borderRadius: '0 4px 4px 0',
       zIndex: 9
     },

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -28,7 +28,7 @@ const headers = {
   'Accept': 'text/plain, */*; q=0.01'
 };
 
-import { baseApi } from '../utils/axios-config';
+import { baseApi, transformApi } from '../utils/axios-config';
 
 export const getTenants = (): Promise<AxiosResponse<Tenants>> =>
   baseApi.get('/tenants');
@@ -97,7 +97,7 @@ export const getTableSchema = (name: string): Promise<AxiosResponse<TableSchema>
   baseApi.get(`/tables/${name}/schema`);
 
 export const getQueryResult = (params: Object, url: string): Promise<AxiosResponse<SQLResult>> =>
-  baseApi.post(`/${url}`, params, {headers});
+  transformApi.post(`/${url}`, params, {headers});
 
 export const getClusterInfo = (): Promise<AxiosResponse<ClusterName>> =>
   baseApi.get('/cluster/info');

--- a/pinot-controller/src/main/resources/app/styles/styles.css
+++ b/pinot-controller/src/main/resources/app/styles/styles.css
@@ -116,7 +116,7 @@ h3.accordion-subtitle:before, h3.accordion-subtitle:after {
 }
 
 .MuiListItem-root.Mui-selected, .MuiListItem-root.Mui-selected:hover {
-  background-color: rgb(66 133 244 / 0.3) !important;
+  background-color: #c0d5f8 !important;
 }
 .box-border{
   border: 1px #ccc solid;

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -69,6 +69,7 @@ import {
   authenticateUser
 } from '../requests';
 import Utils from './Utils';
+const JSONbig = require('json-bigint')({'storeAsString': true})
 
 // This method is used to display tenants listing on cluster manager home page
 // API: /tenants
@@ -218,6 +219,7 @@ const getAsObject = (str: SQLResult) => {
 // Expected Output: {columns: [], records: []}
 const getQueryResults = (params, url, checkedOptions) => {
   return getQueryResult(params, url).then(({ data }) => {
+    data = JSONbig.parse(data);
     let queryResponse = null;
 
     queryResponse = getAsObject(data);

--- a/pinot-controller/src/main/resources/app/utils/axios-config.ts
+++ b/pinot-controller/src/main/resources/app/utils/axios-config.ts
@@ -51,3 +51,5 @@ const handleConfig = (config: any) => {
 export const baseApi = axios.create({ baseURL: '/' });
 baseApi.interceptors.request.use(handleConfig, handleError);
 baseApi.interceptors.response.use(handleResponse, handleError);
+
+export const transformApi = axios.create({baseURL: '/', transformResponse: [data => data]});

--- a/pinot-controller/src/main/resources/package-lock.json
+++ b/pinot-controller/src/main/resources/package-lock.json
@@ -1022,6 +1022,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -4869,6 +4874,14 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         }
+      }
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "json-parse-better-errors": {

--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -71,6 +71,7 @@
     "fs": "0.0.1-security",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "^4.2.1",
+    "json-bigint": "^1.0.0",
     "jsonlint": "^1.6.3",
     "lodash": "^4.17.17",
     "moment": "^2.27.0",


### PR DESCRIPTION
Fix #5829
Added json-bigint package and for `sql` and `pql` API disabling native JSON parsing and using json-bigint parser.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
