### PR TITLE
Add timestamp datatype support in JDBC (#7117)

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
@@ -106,4 +107,37 @@
       <artifactId>jsr305</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -28,11 +28,13 @@ import java.sql.Timestamp;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.client.base.AbstractBasePreparedStatement;
 import org.apache.pinot.client.utils.DateTimeUtils;
+import org.apache.pinot.client.utils.DriverUtils;
 
 
 public class PinotPreparedStatement extends AbstractBasePreparedStatement {
 
   private static final String QUERY_FORMAT = "sql";
+  private static final String LIMIT_STATEMENT = "LIMIT";
   private Connection _connection;
   private org.apache.pinot.client.Connection _session;
   private ResultSetGroup _resultSetGroup;
@@ -40,13 +42,17 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   private String _query;
   private boolean _closed;
   private ResultSet _resultSet;
+  private int _maxRows = Integer.MAX_VALUE;
 
   public PinotPreparedStatement(PinotConnection connection, String query) {
     _connection = connection;
     _session = connection.getSession();
-    _query = query;
     _closed = false;
-    _preparedStatement = new PreparedStatement(_session, new Request(QUERY_FORMAT, query));
+    _query = query;
+    if(!DriverUtils.queryContainsLimitStatement(_query)) {
+      _query = _query.concat(" " + LIMIT_STATEMENT + " " + _maxRows);
+    }
+    _preparedStatement = new PreparedStatement(_session, new Request(QUERY_FORMAT, _query));
   }
 
   @Override
@@ -234,7 +240,6 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
     return execute(sql);
   }
 
-
   @Override
   public ResultSet getResultSet()
       throws SQLException {
@@ -255,6 +260,30 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
       throws SQLException {
     validateState();
     return _connection;
+  }
+
+  @Override
+  public int getFetchSize()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setFetchSize(int rows)
+      throws SQLException {
+    _maxRows = rows;
+  }
+
+  @Override
+  public int getMaxRows()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setMaxRows(int max)
+      throws SQLException {
+    _maxRows = max;
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.client.utils;
 
 import java.net.URI;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +36,7 @@ public class DriverUtils {
   public static final String QUERY_SEPERATOR = "&";
   public static final String PARAM_SEPERATOR = "=";
   public static final String CONTROLLER = "controller";
+  private static final String LIMIT_STATEMENT_REGEX = "\\s(limit)\\s";
 
   private DriverUtils() {
   }
@@ -99,6 +103,9 @@ public class DriverUtils {
       case "BYTES":
         columnsSQLDataType = Types.BINARY;
         break;
+      case "TIMESTAMP":
+        columnsSQLDataType = Types.TIMESTAMP;
+        break;
       default:
         columnsSQLDataType = Types.NULL;
     }
@@ -132,9 +139,18 @@ public class DriverUtils {
       case "BYTES":
         columnsJavaClassName = byte.class.getTypeName();
         break;
+      case "TIMESTAMP":
+        columnsJavaClassName = Timestamp.class.getTypeName();
+        break;
       default:
         columnsJavaClassName = String.class.getTypeName();
     }
     return columnsJavaClassName;
+  }
+
+  public static boolean queryContainsLimitStatement(String query) {
+    Pattern pattern = Pattern.compile(LIMIT_STATEMENT_REGEX, Pattern.CASE_INSENSITIVE);
+    Matcher matcher = pattern.matcher(query);
+    return matcher.find();
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
@@ -51,7 +51,9 @@ public class PinotPreparedStatementTest {
     preparedStatement.setFloat(6, 1.4f);
     preparedStatement.executeQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         "SELECT * FROM dummy WHERE name = 'foo' and age = 20 and score = 98.1 and ts = 123456789 and eligible = 'true' and sub_score = 1.4");
 
     preparedStatement.clearParameters();
@@ -63,7 +65,9 @@ public class PinotPreparedStatementTest {
     preparedStatement.setFloat(6, 0);
     preparedStatement.executeQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         "SELECT * FROM dummy WHERE name = '' and age = 0 and score = 0.0 and ts = 0 and eligible = 'false' and sub_score = 0.0");
   }
 
@@ -81,8 +85,9 @@ public class PinotPreparedStatementTest {
 
     String expectedDate = DateTimeUtils.dateToString(new Date(currentTimestamp));
     String expectedTime = DateTimeUtils.timeStampToString(new Timestamp(currentTimestamp));
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(), String
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(), String
         .format("SELECT * FROM dummy WHERE date = '%s' and updated_at = '%s' and created_at = '%s'", expectedDate,
             expectedTime, expectedTime));
   }
@@ -96,13 +101,16 @@ public class PinotPreparedStatementTest {
     String value = "1234567891011121314151617181920";
     preparedStatement.setBigDecimal(1, new BigDecimal(value));
     preparedStatement.executeQuery();
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", value));
 
     preparedStatement.clearParameters();
     preparedStatement.setBytes(1, value.getBytes());
     preparedStatement.executeQuery();
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", Hex.encodeHexString(value.getBytes())));
   }
 }


### PR DESCRIPTION
Addresses 3 issues with JDBC drivers
- Adds support for Timestamp datatype so that function returning that datatype can be queried by JDBC
-  Append `LIMIT [maxRows]` to the query so that the number of rows configured with `setMaxRows` or `setFetchSize` are returned rather than the default 10 rows.
- Include all the dependencies in JDBC shaded jar so that java-client and pinot-all jars are not required to be copied to the Drivers.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
